### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/model.py
+++ b/model.py
@@ -25,7 +25,7 @@ class User(db.Model):
 
     def __repr__(self):
         """Provide helpful representation when printed."""
-        return "<User user_id=%s username=%s>" % (self.id, self.username)
+        return "<User user_id={0!s} username={1!s}>".format(self.id, self.username)
 
 class House(db.Model):
     """House information"""
@@ -39,7 +39,7 @@ class House(db.Model):
 
     def __repr__(self):
         """Provide helpful representation when printed."""
-        return "<House house_id=%s house_name=%s>" % (self.id, self.name)
+        return "<House house_id={0!s} house_name={1!s}>".format(self.id, self.name)
 
 class HouseChore(db.Model):
     """House chore with house preferred frequency & due date"""
@@ -62,7 +62,7 @@ class HouseChore(db.Model):
 
     def __repr__(self):
         """Provide helpful representation when printed."""
-        return "<HouseChore house_chore_id=%s chore_id= %s day=%s week_freq=%s>" % (self.id, self.chore_id, self.day, self.week_freq)
+        return "<HouseChore house_chore_id={0!s} chore_id= {1!s} day={2!s} week_freq={3!s}>".format(self.id, self.chore_id, self.day, self.week_freq)
 
 class Chore(db.Model):
     """Generic chore object"""
@@ -75,7 +75,7 @@ class Chore(db.Model):
 
     def __repr__(self):
         """Provide helpful representation when printed."""
-        return "<Chore chore_id=%s chore_name=%s>" % (self.id, self.name)
+        return "<Chore chore_id={0!s} chore_name={1!s}>".format(self.id, self.name)
 
 class UserChore(db.Model):
     """Chore that is assigned to a user with a due date"""
@@ -100,7 +100,7 @@ class UserChore(db.Model):
 
     def __repr__(self):
         """Provide helpful representation when printed."""
-        return "<UserChore user_chore_id=%s is_done=%s due_date=%s active=%s>" % (self.id, self.is_done, self.due_date.strftime("%m/%d/%y"), self.is_active)
+        return "<UserChore user_chore_id={0!s} is_done={1!s} due_date={2!s} active={3!s}>".format(self.id, self.is_done, self.due_date.strftime("%m/%d/%y"), self.is_active)
 
 
 

--- a/server.py
+++ b/server.py
@@ -280,7 +280,7 @@ def create_user_chores():
 
     # use enumerate to create an index for each house chore that allows for easy assignment
     for index, house_chore in enumerate(house.house_chores):
-        print "index: %s, house_chore: %s" % (index, house_chore)
+        print "index: {0!s}, house_chore: {1!s}".format(index, house_chore)
 
         # while schedule start day (ie Sunday) != house chore day
         while datetime.datetime.strftime(init_sched_date,"%A") != house_chore.day: 
@@ -300,7 +300,7 @@ def create_user_chores():
             housemate = housemates_list[(index + i) % num_housemates]
             print "HOUSEMATE: ", housemate
 
-            print "user_id: %s, chore_id: %s, due_date: %s" % (housemate.id, house_chore.chore.id, due_date.strftime("%A, %m/%d/%y"))
+            print "user_id: {0!s}, chore_id: {1!s}, due_date: {2!s}".format(housemate.id, house_chore.chore.id, due_date.strftime("%A, %m/%d/%y"))
 
             new_userchore = UserChore(user_id=housemate.id, 
                                         chore_id=house_chore.chore.id,
@@ -411,7 +411,7 @@ def recreate_user_chores():
 
     # use enumerate to create an index for each house chore that allows for easy assignment
     for index, house_chore in enumerate(house.house_chores):
-        print "index: %s, house_chore: %s" % (index, house_chore)
+        print "index: {0!s}, house_chore: {1!s}".format(index, house_chore)
 
         # while schedule start day (ie Sunday) != house chore day
         while datetime.datetime.strftime(init_sched_date,"%A") != house_chore.day: 
@@ -431,7 +431,7 @@ def recreate_user_chores():
             housemate = housemates_list[(index + i) % num_housemates]
             print "HOUSEMATE: ", housemate
 
-            print "user_id: %s, chore_id: %s, due_date: %s" % (housemate.id, house_chore.chore.id, due_date.strftime("%A, %m/%d/%y"))
+            print "user_id: {0!s}, chore_id: {1!s}, due_date: {2!s}".format(housemate.id, house_chore.chore.id, due_date.strftime("%A, %m/%d/%y"))
 
             new_userchore = UserChore(user_id=housemate.id, 
                                         chore_id=house_chore.chore.id,

--- a/tests.py
+++ b/tests.py
@@ -93,7 +93,7 @@ class ServerTestCase(unittest.TestCase):
 
         # use enumerate to create an index for each house chore that allows for easy assignment
         for index, house_chore in enumerate(house.house_chores):
-            print "index: %s, house_chore: %s" % (index, house_chore)
+            print "index: {0!s}, house_chore: {1!s}".format(index, house_chore)
 
             # while schedule start day (ie Sunday) != house chore day
             while datetime.datetime.strftime(init_sched_date,"%A") != house_chore.day: 
@@ -113,7 +113,7 @@ class ServerTestCase(unittest.TestCase):
                 housemate = housemates_list[(index + i) % num_housemates]
                 print "HOUSEMATE: ", housemate
 
-                print "user_id: %s, chore_id: %s, due_date: %s" % (housemate.id, house_chore.chore.id, due_date.strftime("%A, %m/%d/%y"))
+                print "user_id: {0!s}, chore_id: {1!s}, due_date: {2!s}".format(housemate.id, house_chore.chore.id, due_date.strftime("%A, %m/%d/%y"))
 
                 new_userchore = UserChore(user_id=housemate.id, 
                                             chore_id=house_chore.chore.id,


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:janet:choreme?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:janet:choreme?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
